### PR TITLE
Add macOS style and player widgets

### DIFF
--- a/source/client.lua
+++ b/source/client.lua
@@ -103,7 +103,7 @@ function SetDisplay(bool, typeName, bg, chars)
 end
 
 function start(switch)
-    characters, perms = lib.callback.await("ND_Characters:fetchCharacters")
+    characters, perms, players = lib.callback.await("ND_Characters:fetchCharacters")
     if switch then
         local ped = PlayerPedId()
         SwitchOutPlayer(ped, 0, 1)
@@ -117,6 +117,10 @@ function start(switch)
     SendNUIMessage({
         type = "refresh",
         characters = json.encode(characters)
+    })
+    SendNUIMessage({
+        type = "playersOnline",
+        players = json.encode(players)
     })
     SendNUIMessage({
         type = "logo",
@@ -203,10 +207,16 @@ RegisterNUICallback("newCharacter", function(data)
             return lib.print.warn("creating character unsuccessful")
         end
         characters[player.id] = player
+        local _, _, plys = lib.callback.await("ND_Characters:fetchCharacters")
+        players = plys or players
         SendNUIMessage({
             type = "refresh",
             characters = json.encode(characters),
             characterAmount = ("%d/%d"):format(tablelength(characters), config.configuration.characterLimit)
+        })
+        SendNUIMessage({
+            type = "playersOnline",
+            players = json.encode(players)
         })
     end, {
         firstName = data.firstName,
@@ -225,10 +235,16 @@ RegisterNUICallback("editCharacter", function(data)
             return lib.print.warn("editing character unsuccessful")
         end
         characters[player.id] = player
+        local _, _, plys = lib.callback.await("ND_Characters:fetchCharacters")
+        players = plys or players
         SendNUIMessage({
             type = "refresh",
             characters = json.encode(characters),
             characterAmount = ("%d/%d"):format(tablelength(characters), config.configuration.characterLimit)
+        })
+        SendNUIMessage({
+            type = "playersOnline",
+            players = json.encode(players)
         })
     end, {
         id = data.id,
@@ -246,10 +262,16 @@ RegisterNUICallback("delCharacter", function(data)
     lib.callback("ND_Characters:delete", false, function(success)
         if not success then return end
         characters[data.character] = nil
+        local _, _, plys = lib.callback.await("ND_Characters:fetchCharacters")
+        players = plys or players
         SendNUIMessage({
             type = "refresh",
             characters = json.encode(characters),
             characterAmount = ("%d/%d"):format(tablelength(characters), config.configuration.characterLimit)
+        })
+        SendNUIMessage({
+            type = "playersOnline",
+            players = json.encode(players)
         })
     end, data.character)
 end)

--- a/source/server.lua
+++ b/source/server.lua
@@ -159,7 +159,12 @@ lib.callback.register("ND_Characters:fetchCharacters", function(source)
         end
     end
 
-    return characters, perms
+    local players = {}
+    for _, id in ipairs(GetPlayers()) do
+        players[#players+1] = { id = tonumber(id), name = GetPlayerName(id) }
+    end
+
+    return characters, perms, players
 end)
 
 RegisterNetEvent("ND_Characters:select", function(id)

--- a/ui/index.html
+++ b/ui/index.html
@@ -18,6 +18,10 @@
             </div>
 
             <h1 id="serverName"></h1>
+            <div id="playersWidget" class="mainPage">
+                <span id="onlineCount">0</span> players online
+            </div>
+            <ul id="playerList" class="mainPage"></ul>
             <p id="aop" class="mainPage" style="margin-bottom: -1vh;"></p>
             <p class="mainPage">Select or create a character:</p>
 

--- a/ui/script.js
+++ b/ui/script.js
@@ -223,6 +223,15 @@ window.addEventListener("message", function(event) {
         }
     }
 
+    if (item.type === "playersOnline") {
+        const players = JSON.parse(item.players || '[]');
+        $("#onlineCount").text(players.length);
+        $("#playerList").empty();
+        players.forEach(p => {
+            $("#playerList").append(`<li>${p.name} (#${p.id})</li>`);
+        });
+    }
+
     if (item.type === "logo" && item.logo) {
         $("#logo").attr("src", `../images/${item.logo}`);
     }

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,10 +1,19 @@
+:root {
+    --accent: #0a84ff;
+    --danger: #ff3b30;
+    --background: rgba(30, 30, 30, 0.95);
+    --widget-bg: rgba(50, 50, 50, 0.6);
+}
+
 body {
     display: none;
-    font-family: 'Poppins', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+        Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     background-size: 105%;
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-position: center;
+    color: white;
 }
 #exitGameMenu, #characterCreator, #characterEditor, #deleteCharacterMenu, #spawnLocation {
     display: none;
@@ -16,9 +25,11 @@ body {
     left: 0;
     height: 100vh;
     width: 30vw;
-    background: rgba(8, 8, 8, 0.92);
-    box-shadow: 0 0 15px rgba(0, 0, 0, 0.8);
+    background: var(--background);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(15px);
     position: fixed;
+    padding: 1vh 0;
 }
 
 #charactersSection {
@@ -27,6 +38,24 @@ body {
     padding: none;
     width: 83%;
     overflow-y: scroll;
+}
+
+#playersWidget {
+    margin-top: 1vh;
+}
+
+#playerList {
+    list-style: none;
+    padding: 0;
+    margin: 0 auto 2vh;
+    width: 80%;
+}
+
+#playerList li {
+    background: var(--widget-bg);
+    padding: 0.4vh 0.5vw;
+    margin-bottom: 0.4vh;
+    border-radius: 0.5vh;
 }
 
 ::-webkit-scrollbar {
@@ -82,8 +111,8 @@ body {
     margin-bottom: 0.8vh;
     height: 4.5vh;
     width: 12vw;
-    background: rgb(92, 59, 163);
-    background-image: linear-gradient(90deg, rgba(92,59,163,1) 0%, rgba(51,32,109,1) 100%);
+    background: var(--accent);
+    background-image: none;
     border-radius: 5vw;
     transition: 0.3s;
 }
@@ -93,8 +122,7 @@ body {
     margin-bottom: 5vh;
     height: 4.5vh;
     width: 10vw;
-    background: rgb(191, 45, 65);
-    background: linear-gradient(90deg, rgb(191, 45, 65) 0%, rgb(158, 26, 55) 100%);
+    background: var(--danger);
     border-radius: 5vw;
     transition: 0.3s;
 }
@@ -105,7 +133,7 @@ body {
     margin-left: 5.5vw;
     height: 3vh;
     width: 10vw;
-    background-color: rgba(50, 50, 60, 0.9);
+    background-color: var(--widget-bg);
     border: none;
     border-radius: 0.5vh;
     transition: 0.3s;
@@ -117,7 +145,7 @@ body {
     margin-left: 0.2vw;
     height: 3vh;
     width: 4vw;
-    background-color: rgba(80, 80, 90, 0.9);
+    background-color: var(--accent);
     border: none;
     border-radius: 0.5vh;
     transition: 0.3s;
@@ -127,7 +155,7 @@ body {
     margin-left: 0.2vw;
     height: 3vh;
     width: 4vw;
-    background-color: rgb(200, 40, 40);
+    background-color: var(--danger);
     border: none;
     border-radius: 0.5vh;
     transition: 0.3s;
@@ -205,12 +233,12 @@ body {
     margin-left: 33.7vw;
     margin-bottom: 2vh;
     width: 8vw;
-    background-color: rgb(92, 59, 163);
+    background-color: var(--accent);
 }
 
 .characterResetButton {
     width: 4vw;
-    background-color: rgb(200, 40, 40);
+    background-color: var(--danger);
 }
 
 .characterSubmitButton, .characterResetButton, .confirmationScreenConfirm, .confirmationScreenCancel, .spawnButtons {
@@ -229,7 +257,7 @@ body {
     width: 30vw;
     margin-top: 20vh;
     margin-left: 45vw;
-    background-color: rgba(12, 12, 12, 0.94);
+    background-color: var(--background);
     border-radius: 3vh;
 }
 
@@ -238,19 +266,19 @@ body {
     margin-left: 19%;
     margin-right: 5%;
     width: 8vw;
-    background-color: rgb(92, 59, 163);
+    background-color: var(--accent);
 }
 
 .confirmationScreenCancel {
     width: 8vw;
-    background-color: rgb(200, 40, 40);
+    background-color: var(--danger);
 }
 
 .spawnMenu {
     height: 39%;
     width: 40vw;
     margin: auto 0 auto 40vw;
-    background-color: rgba(12, 12, 12, 0.94);
+    background-color: var(--background);
     border-radius: 3vh;
 }
 
@@ -266,7 +294,7 @@ body {
     text-align: center;
     width: 95%;
     height: 4vh;
-    background-color: rgb(92, 59, 163);
+    background-color: var(--accent);
 }
 
 .text {


### PR DESCRIPTION
## Summary
- restyle body using modern macOS-like palette
- add players online widget and player list
- update client/server to pass and handle player list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841b7de5798832ca728e9fef3d4857c